### PR TITLE
기수법 변환 함수 BASE64에서 BASE62로 변경

### DIFF
--- a/lib/convertNumeralSystem.ts
+++ b/lib/convertNumeralSystem.ts
@@ -1,25 +1,35 @@
-function convert10to64(decimal: number) {
-  const base64Chars =
-    'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/';
+const BASE_LENGTH = 62;
+
+const convert10to62 = (decimal: number) => {
+  const baseChars = process.env.BASE62_CHARS;
+  if (!baseChars) throw new Error('BASE62_CHARS is not defined');
+  const length = baseChars.length;
+  if (length !== BASE_LENGTH)
+    throw new Error('BASE62_CHARS length must be ' + BASE_LENGTH);
+
   let result = '';
   if (decimal === 0) {
-    return 'A';
+    return baseChars[0];
   }
   while (decimal > 0) {
-    result = base64Chars[decimal % 64] + result;
-    decimal = Math.floor(decimal / 64);
+    result = baseChars[decimal % length] + result;
+    decimal = Math.floor(decimal / length);
   }
   return result;
-}
+};
 
-function convert64to10(base64: string) {
-  const base64Chars =
-    'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/';
+const convert62to10 = (base62: string) => {
+  const baseChars = process.env.BASE62_CHARS;
+  if (!baseChars) throw new Error('BASE62_CHARS is not defined');
+  const length = baseChars.length;
+  if (length !== BASE_LENGTH)
+    throw new Error('BASE62_CHARS length must be ' + BASE_LENGTH);
+
   let result = 0;
-  for (let i = 0; i < base64.length; i++) {
-    result = result * 64 + base64Chars.indexOf(base64[i]);
+  for (let i = 0; i < base62.length; i++) {
+    result = result * length + baseChars.indexOf(base62[i]);
   }
   return result;
-}
+};
 
-export { convert10to64, convert64to10 };
+export { convert10to62, convert62to10 };


### PR DESCRIPTION
## **✨ 기수법 변환 함수 BASE64에서 BASE62로 변경**

### **🔗 관련 이슈**

Closes #21 

---

### **📌 변경 사항**

- ✅ 변환 기준 base64에서 base62로 변겨

---

### **🛠 테스트 내역**

- [x] **테스트 코드 실행 완료**